### PR TITLE
fix: pin torch==2.0.1 to match torchvision==0.15.2

### DIFF
--- a/applications/insurance-claims-processing/requirements-analytics.txt
+++ b/applications/insurance-claims-processing/requirements-analytics.txt
@@ -8,7 +8,7 @@ numpy==1.24.3
 scipy==1.11.1
 
 # Deep Learning (optional)
-torch>=2.8.0
+torch==2.0.1
 torchvision==0.15.2
 
 # Time Series Analysis


### PR DESCRIPTION
requirements-analytics.txt had `torch>=2.8.0` (doesn't exist) with `torchvision==0.15.2` (requires torch==2.0.x) — incompatible. Pinned to `torch==2.0.1`.