### PR TITLE
fix: replace hardcoded ECR account ID with ${ECR_REGISTRY}/${IMAGE_TAG}

### DIFF
--- a/infrastructure/kubernetes/claims-simulator.yaml
+++ b/infrastructure/kubernetes/claims-simulator.yaml
@@ -20,7 +20,7 @@ spec:
         karpenter.sh/nodepool: cpu-nodepool
       containers:
       - name: claims-simulator
-        image: 123255318457.dkr.ecr.us-west-2.amazonaws.com/insurance-claims/claims-simulator:latest
+        image: ${ECR_REGISTRY}/insurance-claims/claims-simulator:${IMAGE_TAG}
         securityContext:
           runAsNonRoot: true
           runAsUser: 1000

--- a/infrastructure/kubernetes/claims-web-interface.yaml
+++ b/infrastructure/kubernetes/claims-web-interface.yaml
@@ -20,7 +20,7 @@ spec:
         karpenter.sh/nodepool: cpu-nodepool
       containers:
       - name: web-interface
-        image: 123255318457.dkr.ecr.us-west-2.amazonaws.com/insurance-claims/web-interface:latest
+        image: ${ECR_REGISTRY}/insurance-claims/web-interface:${IMAGE_TAG}
         securityContext:
           runAsNonRoot: true
           runAsUser: 1000

--- a/infrastructure/kubernetes/coordinator.yaml
+++ b/infrastructure/kubernetes/coordinator.yaml
@@ -20,7 +20,7 @@ spec:
         karpenter.sh/nodepool: cpu-nodepool
       containers:
       - name: coordinator
-        image: 123255318457.dkr.ecr.us-west-2.amazonaws.com/insurance-claims/coordinator:latest
+        image: ${ECR_REGISTRY}/insurance-claims/coordinator:${IMAGE_TAG}
         securityContext:
           runAsNonRoot: true
           runAsUser: 1000

--- a/infrastructure/kubernetes/external-integrations.yaml
+++ b/infrastructure/kubernetes/external-integrations.yaml
@@ -20,7 +20,7 @@ spec:
         karpenter.sh/nodepool: cpu-nodepool
       containers:
       - name: external-integrations
-        image: 123255318457.dkr.ecr.us-west-2.amazonaws.com/insurance-claims/external-integrations:latest
+        image: ${ECR_REGISTRY}/insurance-claims/external-integrations:${IMAGE_TAG}
         securityContext:
           runAsNonRoot: true
           runAsUser: 1000

--- a/infrastructure/kubernetes/policy-agent.yaml
+++ b/infrastructure/kubernetes/policy-agent.yaml
@@ -20,7 +20,7 @@ spec:
         karpenter.sh/nodepool: cpu-nodepool
       containers:
       - name: policy-agent
-        image: 123255318457.dkr.ecr.us-west-2.amazonaws.com/insurance-claims/policy-agent:latest
+        image: ${ECR_REGISTRY}/insurance-claims/policy-agent:${IMAGE_TAG}
         securityContext:
           runAsNonRoot: true
           runAsUser: 1000

--- a/infrastructure/kubernetes/shared-memory.yaml
+++ b/infrastructure/kubernetes/shared-memory.yaml
@@ -20,7 +20,7 @@ spec:
         karpenter.sh/nodepool: cpu-nodepool
       containers:
       - name: shared-memory
-        image: 123255318457.dkr.ecr.us-west-2.amazonaws.com/insurance-claims/shared-memory:latest
+        image: ${ECR_REGISTRY}/insurance-claims/shared-memory:${IMAGE_TAG}
         securityContext:
           runAsNonRoot: true
           runAsUser: 1000


### PR DESCRIPTION
K8s manifests had old account ID `123255318457` hardcoded. `deploy-kubernetes.sh` uses `envsubst` to substitute `${ECR_REGISTRY}` and `${IMAGE_TAG}` but the substitution never fired because the manifests used hardcoded values instead of placeholders.