### PR TITLE
fix: add PYTHONUSERBASE to Dockerfiles (uvicorn not found)

### DIFF
--- a/applications/insurance-claims-processing/docker/Dockerfile.coordinator
+++ b/applications/insurance-claims-processing/docker/Dockerfile.coordinator
@@ -36,6 +36,7 @@ COPY --chown=insurance:insurance src/ ./src/
 
 # Set environment variables
 ENV PYTHONPATH=/app
+ENV PYTHONUSERBASE=/home/webapp/.local
 ENV PYTHONUNBUFFERED=1
 ENV PATH=/home/insurance/.local/bin:$PATH
 

--- a/applications/insurance-claims-processing/docker/Dockerfile.external-integrations
+++ b/applications/insurance-claims-processing/docker/Dockerfile.external-integrations
@@ -40,6 +40,7 @@ COPY --chown=integrations:integrations src/shared/ ./src/shared/
 
 # Set environment variables
 ENV PYTHONPATH=/app
+ENV PYTHONUSERBASE=/home/webapp/.local
 ENV PYTHONUNBUFFERED=1
 ENV PATH=/home/integrations/.local/bin:$PATH
 

--- a/applications/insurance-claims-processing/docker/Dockerfile.human-workflow
+++ b/applications/insurance-claims-processing/docker/Dockerfile.human-workflow
@@ -40,6 +40,7 @@ COPY --chown=workflow:workflow src/shared/ ./src/shared/
 
 # Set environment variables
 ENV PYTHONPATH=/app
+ENV PYTHONUSERBASE=/home/webapp/.local
 ENV PYTHONUNBUFFERED=1
 ENV PATH=/home/workflow/.local/bin:$PATH
 

--- a/applications/insurance-claims-processing/docker/Dockerfile.web-interface
+++ b/applications/insurance-claims-processing/docker/Dockerfile.web-interface
@@ -46,6 +46,7 @@ COPY --chown=webapp:webapp src/static/ ./src/static/
 
 # Set environment variables
 ENV PYTHONPATH=/app
+ENV PYTHONUSERBASE=/home/webapp/.local
 ENV PYTHONUNBUFFERED=1
 ENV PATH=/home/webapp/.local/bin:$PATH
 


### PR DESCRIPTION
Multi-stage Dockerfiles install packages with `pip install --user` in the builder stage, copying `/root/.local` to `/home/webapp/.local` in the runtime stage. Without `PYTHONUSERBASE=/home/webapp/.local`, `python -m uvicorn` can't find the packages, causing `No module named uvicorn` at startup.