### PR TITLE
fix: pin starlette<1.0.0; add MongoDB fsGroup+tmpfs

### DIFF
--- a/applications/insurance-claims-processing/requirements-production.txt
+++ b/applications/insurance-claims-processing/requirements-production.txt
@@ -1,5 +1,6 @@
 # Production-grade Autonomous Agentic System - Latest Versions
-fastapi>=0.115.0
+fastapi>=0.115.0,<0.116.0
+starlette>=0.41.0,<1.0.0
 uvicorn[standard]>=0.32.0
 pydantic>=2.10.0
 httpx>=0.28.0

--- a/infrastructure/kubernetes/mongodb-deployment.yaml
+++ b/infrastructure/kubernetes/mongodb-deployment.yaml
@@ -47,6 +47,8 @@ spec:
       labels:
         app: mongodb
     spec:
+      securityContext:
+        fsGroup: 999  # Ensures mounted volumes are writable by MongoDB user
       nodeSelector:
         karpenter.sh/nodepool: cpu-nodepool
       containers:
@@ -78,6 +80,8 @@ spec:
         volumeMounts:
         - name: mongodb-storage
           mountPath: /data/db
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             memory: "256Mi"
@@ -109,6 +113,8 @@ spec:
       - name: mongodb-storage
         persistentVolumeClaim:
           claimName: mongodb-pvc
+      - name: tmp
+        emptyDir: {}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Two fixes:
1. **Starlette 1.0.0 breaking change**: `TemplateResponse` API changed in 1.0.0, causing `TypeError: unhashable type: 'dict'`. Pin `starlette<1.0.0`.
2. **MongoDB permissions**: `readOnlyRootFilesystem: true` blocked socket creation in `/tmp`. Add `emptyDir` volume for `/tmp` and `fsGroup: 999` so PVC is writable by MongoDB user.