### PR TITLE
feat: tear down EKS stack and all supporting infrastructure (closes #25)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ logs/
 .kiro/telemetry/
 docs/reviews/
 kubectl
+destroy.plan

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
-# AI-Powered Insurance Claims Processing on AWS EKS
+# AI-Powered Insurance Claims Processing on AWS
 
 <p align="center">
-  <img src="https://img.shields.io/badge/AWS-EKS-FF9900?logo=amazon-aws&logoColor=white" alt="AWS EKS"/>
-  <img src="https://img.shields.io/badge/Kubernetes-1.33-326CE5?logo=kubernetes&logoColor=white" alt="Kubernetes"/>
-  <img src="https://img.shields.io/badge/Terraform-1.5+-7B42BC?logo=terraform&logoColor=white" alt="Terraform"/>
+  <img src="https://img.shields.io/badge/AWS-Fargate-FF9900?logo=amazon-aws&logoColor=white" alt="AWS Fargate"/>
+  <img src="https://img.shields.io/badge/CDK-TypeScript-3178C6?logo=typescript&logoColor=white" alt="CDK TypeScript"/>
   <img src="https://img.shields.io/badge/Python-3.11-3776AB?logo=python&logoColor=white" alt="Python"/>
-  <img src="https://img.shields.io/badge/MongoDB-6.0-47A248?logo=mongodb&logoColor=white" alt="MongoDB"/>
+  <img src="https://img.shields.io/badge/Amazon_Bedrock-AgentCore-FF9900?logo=amazon-aws&logoColor=white" alt="Amazon Bedrock AgentCore"/>
+  <img src="https://img.shields.io/badge/DynamoDB-blue?logo=amazon-dynamodb&logoColor=white" alt="DynamoDB"/>
 </p>
+
+> **⚠️ Migration in Progress** — The EKS/Terraform/MongoDB/Ollama stack has been torn down (2026-05-04, issue #25).
+> The repository is being migrated to **CDK TypeScript + Fargate + DynamoDB + Bedrock AgentCore** (issues #2–#6).
+> The application source code in `applications/` carries forward to the new stack.
 
 ## 🎯 Overview
 
-A **production-ready** AI-powered insurance claims processing application demonstrating advanced multi-agent AI patterns with LangGraph on AWS EKS. This repository showcases intelligent, autonomous decision-making systems for insurance claims adjudication with fraud detection.
+An AI-powered insurance claims processing application demonstrating advanced multi-agent AI patterns with Amazon Bedrock AgentCore on AWS Fargate. This repository showcases intelligent, autonomous decision-making systems for insurance claims adjudication with fraud detection.
 
 ## ✨ Key Features
 
@@ -24,15 +28,16 @@ A **production-ready** AI-powered insurance claims processing application demons
 
 ## 🚀 Quick Start
 
-### Prerequisites
+> **Note:** The EKS/Terraform stack has been torn down (issue #25, 2026-05-04). The CDK + Fargate stack is under active development (issues #2–#6). Deployment instructions will be updated when the new stack is ready.
+
+### Prerequisites (CDK migration — issues #2–#6)
 
 ```bash
 # Required tools
 - AWS CLI (configured with credentials)
-- kubectl (v1.27+)
-- Terraform (v1.5+)
+- Node.js 18+ (for CDK TypeScript)
+- AWS CDK v2
 - Docker (v20.10+)
-- jq
 ```
 
 ### One-Command Deployment
@@ -241,17 +246,17 @@ The Supervisor Portal provides enterprise-grade analytics:
 
 ## 🛠️ Technology Stack
 
+> **Note:** The table below reflects the **target architecture** (CDK + Fargate migration in progress). The previous EKS/Terraform/MongoDB/Ollama stack was torn down 2026-05-04 (issue #25).
+
 | Layer | Technology | Purpose |
 |-------|-----------|---------|
-| **Orchestration** | AWS EKS | Managed Kubernetes |
-| **IaC** | Terraform | Infrastructure as Code |
-| **Compute** | Karpenter | Node auto-scaling |
-| **Networking** | AWS VPC + ALB | Load balancing & routing |
-| **AI Framework** | LangGraph | Agentic workflows |
-| **LLM** | Ollama (Qwen2.5) | Local LLM inference |
-| **Database** | MongoDB | Document storage |
-| **Cache** | Redis | Session & response caching |
-| **Backend** | FastAPI + Python | Web services |
+| **Orchestration** | AWS Fargate (ECS) | Serverless containers — no node management |
+| **IaC** | CDK TypeScript | Infrastructure as Code |
+| **AI Framework** | Strands + Bedrock AgentCore | Agentic workflows |
+| **LLM** | Claude Sonnet 4.5 (Bedrock) | AI inference |
+| **Database** | DynamoDB | Document storage for claims, policies |
+| **Cache** | ElastiCache Redis | Session & response caching |
+| **Backend** | FastAPI + Python 3.11 | Web services |
 | **Monitoring** | CloudWatch | Metrics & logging |
 | **Secrets** | AWS Secrets Manager | Credential management |
 

--- a/docs/specs/In-Progress/issue-25-eks-teardown-spec.md
+++ b/docs/specs/In-Progress/issue-25-eks-teardown-spec.md
@@ -1,0 +1,488 @@
+# Specification: EKS Cluster Teardown (Issue #25)
+
+## 0. Research Findings
+
+### Actual Scope (verified from codebase)
+
+**Terraform-managed resources (will be destroyed by `terraform destroy`):**
+- EKS cluster `agentic-eks-cluster` (terraform-aws-modules/eks ~> 20.31)
+- EKS managed node group `general` (m5.large, 2 nodes)
+- EKS OIDC provider (for IRSA) — distinct from GitHub Actions OIDC provider
+- KMS key `eks-secrets` (7-day deletion window) + alias
+- KMS key `secrets-encryption` (10-day deletion window) + alias
+- VPC + 3 private subnets + 3 public subnets + NAT gateway + IGW + route tables + flow logs
+- Security groups: `additional`, `langgraph_services`, `langgraph_alb`, `mongodb_rotation_lambda`
+- Secrets Manager: `mongodb-credentials`, `mongodb-credentials-encrypted`, `langgraph-secrets` (all `recovery_window=0`)
+- S3 bucket `langgraph-storage-*` (versioning enabled, `force_destroy` NOT set — needs fix)
+- S3 bucket `app-data-*` (conditional, `force_destroy=true`)
+- ALB `langgraph-alb` (Terraform-managed, `enable_deletion_protection=false`)
+- CloudWatch log group `/aws/eks/agentic-eks-cluster/langgraph` (30-day retention)
+- IRSA roles: `ebs-csi-driver`, `external-secrets`
+- IAM policy `external-secrets-policy`, `langgraph-service-policy`
+- IAM role `mongodb-rotation-lambda` + inline policy
+- EKS Blueprints Addons module: Karpenter 1.7.1, ALB controller v2.17.1, External Secrets 0.11.0, metrics-server, EBS CSI driver, CoreDNS, VPC-CNI, kube-proxy
+- Karpenter SQS queue + EventBridge rules (via `karpenter_enable_spot_termination=true`)
+- Karpenter node IAM role + access entry
+- `kubectl_manifest` resources: cpu-nodeclass, gpu-nodeclass (×2 — duplicate in karpenter-nodepools.tf AND production-terraform-addon.tf), cpu-nodepool, gpu-nodepool (×2 — same duplicate), gp3/gp3-high-performance/gp3-retain/gp2 StorageClasses, nvidia DaemonSet (conditional)
+- `time_sleep.wait_for_karpenter` (120s)
+- `random_string.bucket_suffix`, `random_password.*` resources
+
+**NOT in Terraform state (require manual cleanup):**
+- Kubernetes ALB from Ingress resource (`insurance-claims-alb-1814481405.us-west-2.elb.amazonaws.com`)
+- Karpenter-provisioned EC2 nodes
+- EBS volumes from MongoDB/Redis PVCs
+- ECR repos: `insurance-claims/web-interface`, `insurance-claims/coordinator`, `insurance-claims/analytics`, `insurance-claims/simulator` (created by `build-docker-images.sh`)
+- CloudWatch log group `/aws/eks/agentic-eks-cluster/cluster` (`create_cloudwatch_log_group=false`)
+- Kubernetes namespace `insurance-claims` and all workloads within it
+
+**MUST BE PRESERVED (not in TF state, safe from destroy):**
+- IAM role `github-actions-deploy` (not in iam.tf)
+- GitHub Actions OIDC provider `token.actions.githubusercontent.com` (created by bootstrap-cicd.sh)
+- S3 state bucket `agentic-eks-terraform-state-621967485578` (is the backend, not a managed resource)
+
+### Recommended Approach
+
+**Hybrid: Pre-drain K8s workloads → `terraform destroy`**
+
+Pre-drain eliminates all three VPC-blocking orphan risks (Karpenter EC2 nodes, Ingress ALB, PVC EBS volumes) before Terraform runs. After pre-drain, `terraform destroy` runs cleanly in ~20–30 min with high success rate.
+
+### Alternatives Considered
+
+| Option | Pros | Cons | Verdict |
+|--------|------|------|---------|
+| `terraform destroy` only | Single command | Karpenter nodes + Ingress ALB + PVCs orphaned; VPC deletion fails | ❌ Will fail |
+| Targeted `-target` destroy | Can exclude resources | Doesn't solve orphan problem; 8–12 sequential invocations | ❌ High complexity |
+| Manual console + `state rm` | Maximum control | 60+ resources; not repeatable; high orphan risk | ❌ Too slow |
+| **Hybrid pre-drain + destroy** | Solves all orphan risks; repeatable; ~45 min total | Two-phase; requires kubectl access | ✅ Recommended |
+
+### Edge Cases & Gotchas
+
+- **Duplicate kubectl_manifest resources**: `gpu-nodepool` and `gpu-nodeclass` are defined in BOTH `karpenter-nodepools.tf` AND `production-terraform-addon.tf`. During destroy, the second delete gets a 404 and may error. Pre-deleting via kubectl avoids this.
+- **`langgraph_storage` S3 bucket**: versioning is enabled but `force_destroy` is NOT set. `terraform destroy` will fail if the bucket is non-empty. Must add `force_destroy = true` before running destroy, or empty the bucket manually.
+- **Kubernetes provider auth during destroy**: providers use `aws eks get-token` exec auth. If EKS cluster is deleted mid-destroy, subsequent `kubectl_manifest` deletions fail. TF dependency graph should handle ordering, but interrupted re-runs can break this.
+- **`langgraph_storage` needs `s3:DeleteObjectVersion`**: versioning enabled; the `github-actions-deploy` role only has `s3:DeleteObject`, not `s3:DeleteObjectVersion`. Destroy will fail on versioned objects unless `force_destroy=true` is set (which handles this internally).
+- **KMS keys**: 7–10 day pending deletion window is unavoidable. Keys continue to cost $1/month each during the window.
+- **CloudWatch log group `/aws/eks/agentic-eks-cluster/cluster`**: NOT in TF state, will not be deleted by destroy. Manual cleanup required post-destroy.
+- **ECR repos**: NOT in TF state. Manual `aws ecr delete-repository --force` required.
+- **SQS + EventBridge for Karpenter**: ARE in TF state via `eks_blueprints_addons`. Will be destroyed correctly IF the `github-actions-deploy` role has `sqs:*` and `events:*` (currently missing — must be added before CI-based destroy).
+
+### AWS Constraints
+
+- **IAM permissions gap**: `github-actions-deploy` role is missing `sqs:*`, `events:*`, `s3:DeleteObjectVersion` for destroy. Must be patched before running destroy via CI.
+- **EKS cluster deletion time**: 10–20 min for control plane; 20–40 min total with addons.
+- **ENI cleanup time**: 5–15 min after node termination before VPC subnets can be deleted. Pre-drain mitigates this.
+- **KMS minimum deletion window**: 7 days (AWS hard limit). Cannot be shortened.
+- **ECR `--force` flag**: `aws ecr delete-repository --force` deletes all images atomically. No need to delete images first.
+- **EIP release**: Handled automatically by vpc module when NAT GW is deleted.
+
+### Known Limitations (out of scope)
+
+- Secret rotation Lambda function was never deployed (placeholder only) — no Lambda to clean up.
+- ACM certificate (`acm.tf`) — need to verify if any cert was provisioned.
+- `production-terraform-addon.tf` contains duplicate Karpenter resources — not worth refactoring before destroy.
+
+## 1. Requirements
+
+### Problem Statement
+
+The EKS cluster `agentic-eks-cluster` is generating ~300 Critical/High Linux kernel CVEs (kernel 6.12.74 → 6.12.85) with no path to resolution that isn't a perpetual treadmill. The cluster has no active production or demo use. The target architecture (CDK + Fargate, issues #2–#5) eliminates worker node OS management entirely. The cluster must be torn down surgically — destroying all EKS/VPC/supporting infrastructure while preserving the GitHub Actions OIDC role and Terraform state bucket needed for the CDK migration.
+
+### Users
+
+- **The Team** (hodok) — executing the teardown
+- **GitHub Actions** (`github-actions-deploy` role) — must continue to function post-teardown for CDK work
+
+### Functional Requirements
+
+**Must Have:**
+- FR1: All EKS cluster resources destroyed (control plane, managed node group, addons)
+- FR2: VPC and all networking resources destroyed (subnets, NAT GW, IGW, route tables, flow logs, security groups)
+- FR3: All Secrets Manager secrets deleted (`recovery_window=0` already set)
+- FR4: All IRSA IAM roles and policies deleted
+- FR5: KMS keys scheduled for deletion
+- FR6: S3 `langgraph-storage` bucket emptied and deleted
+- FR7: Karpenter-provisioned EC2 nodes terminated before VPC deletion
+- FR8: Kubernetes Ingress ALB deleted before VPC deletion
+- FR9: MongoDB/Redis PVC EBS volumes deleted before cluster destruction
+- FR10: ECR repos (`insurance-claims/*`) deleted post-destroy
+- FR11: Orphaned CloudWatch log group `/aws/eks/agentic-eks-cluster/cluster` deleted post-destroy
+- FR12: `github-actions-deploy` IAM role preserved (not touched)
+- FR13: GitHub Actions OIDC provider preserved (not touched)
+- FR14: Terraform state bucket `agentic-eks-terraform-state-621967485578` preserved
+
+**Should Have:**
+- FR15: `langgraph_storage` S3 bucket gets `force_destroy = true` added before destroy runs
+- FR16: `github-actions-deploy` role policy patched with missing `sqs:*`, `events:*`, `s3:DeleteObjectVersion` before CI-based destroy
+- FR17: Issues #20 and #21 closed as won't-fix (moot after teardown)
+- FR18: Issue #17 (torch CVEs) closed as won't-fix (analytics image gone after teardown)
+- FR19: README updated to reflect teardown status and CDK migration in progress
+
+**Nice to Have:**
+- FR20: Teardown script (`scripts/teardown.sh`) created for repeatability and documentation
+- FR21: Verification script to confirm no orphaned resources post-destroy
+
+### Non-Functional Requirements
+
+- NFR1: No orphaned AWS resources that continue to accrue cost after teardown
+- NFR2: Teardown is safe to run from local machine (admin role) or CI (`github-actions-deploy` role)
+- NFR3: `github-actions-deploy` role remains functional for CDK work immediately after teardown
+- NFR4: Total teardown time < 60 minutes
+
+### Constraints
+
+- Must NOT delete `github-actions-deploy` IAM role
+- Must NOT delete GitHub Actions OIDC provider (`token.actions.githubusercontent.com`)
+- Must NOT delete S3 state bucket `agentic-eks-terraform-state-621967485578`
+- Must run `terraform destroy` from `infrastructure/terraform/` with existing backend config
+- KMS key deletion window minimum 7 days — unavoidable, accepted
+
+### Integrations
+
+- Terraform state: S3 backend `agentic-eks-terraform-state-621967485578/insurance-demo/terraform.tfstate`
+- kubectl: requires `aws eks update-kubeconfig --name agentic-eks-cluster --region us-west-2` before pre-drain
+- AWS CLI: `hodok-Isengard` assumed role (local) or `github-actions-deploy` (CI)
+
+### Open Questions
+
+- Q1: Should the teardown be run locally (admin role) or via CI (`github-actions-deploy`)? **Recommendation: locally first for safety; CI can be used if local access is unavailable.**
+- Q2: Should `acm.tf` be checked for any provisioned ACM certificates before destroy? **Yes — add to pre-destroy checklist.**
+- Q3: Should the Terraform state bucket be deleted after CDK has its own backend, or kept indefinitely? **Keep until CDK stack is confirmed stable.**
+
+### Acceptance Criteria
+
+- [ ] `terraform destroy` completes with exit code 0
+- [ ] `aws eks describe-cluster --name agentic-eks-cluster` returns ResourceNotFoundException
+- [ ] No EC2 instances with tag `karpenter.sh/discovery=agentic-eks-cluster` in running/pending state
+- [ ] No ALBs with name containing `k8s` or `insurance` in us-west-2
+- [ ] No VPCs with tag `Name=*agentic*` in us-west-2
+- [ ] `aws iam get-role --role-name github-actions-deploy` succeeds
+- [ ] `aws s3 ls s3://agentic-eks-terraform-state-621967485578` succeeds
+- [ ] ECR repos `insurance-claims/*` deleted
+- [ ] CloudWatch log group `/aws/eks/agentic-eks-cluster/cluster` deleted
+- [ ] Issues #17, #20, #21 closed as won't-fix
+- [ ] README updated
+
+## 2. High-Level Design
+
+### Overview
+
+Two-phase teardown: (1) pre-drain Kubernetes resources that are outside Terraform state to eliminate VPC-blocking orphans, then (2) `terraform destroy` to remove all TF-managed resources. Post-destroy manual cleanup handles resources that were never in TF state (ECR, CloudWatch log groups).
+
+### System Context
+
+```mermaid
+flowchart TD
+    A[Phase 0: Code Fix\nforce_destroy + IAM policy patch] --> B[Phase 1: Pre-Drain\nkubectl delete workloads/ingress/nodepools]
+    B --> C[Phase 2: terraform destroy\nAll TF-managed resources]
+    C --> D[Phase 3: Post-Destroy Cleanup\nECR repos + CloudWatch log groups]
+    D --> E[Phase 4: Verification\nNo orphaned resources]
+    E --> F[Phase 5: Issue Hygiene\nClose #17 #20 #21, update README]
+```
+
+### Architectural Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Destroy method | Hybrid pre-drain + `terraform destroy` | Only approach that reliably avoids VPC deletion failures |
+| Execution context | Local (admin role) | Safer for first run; avoids CI permission gaps |
+| `langgraph_storage` fix | Add `force_destroy = true` in code | Required for destroy to succeed on versioned bucket |
+| IAM policy patch | Add `sqs:*`, `events:*`, `s3:DeleteObjectVersion` to `github-actions-deploy` | Required for CI-based destroy; also correct for CDK work |
+| State bucket | Preserve | Needed until CDK stack has its own backend |
+| Teardown script | Create `scripts/teardown.sh` | Documents the process; repeatable if needed |
+
+### Major Phases
+
+**Phase 0 — Code fixes (before running anything):**
+- Add `force_destroy = true` to `aws_s3_bucket.langgraph_storage` in `production-terraform-addon.tf`
+- Patch `github-actions-deploy` IAM role inline policy to add `sqs:*`, `events:*`, `s3:DeleteObjectVersion`
+
+**Phase 1 — Pre-drain (kubectl, ~10–15 min):**
+1. Delete `insurance-claims` namespace → releases PVCs → EBS CSI deletes EBS volumes
+2. Delete Karpenter NodePools + EC2NodeClasses → Karpenter terminates its EC2 nodes
+3. Delete all Ingress objects → ALB controller deletes the Kubernetes-managed ALB
+4. Verify: no running Karpenter EC2 instances, no ALBs in VPC
+
+**Phase 2 — `terraform destroy` (~20–35 min):**
+- Run from `infrastructure/terraform/` with `terraform.tfvars`
+- TF dependency graph handles ordering automatically
+- Expected destroy order: kubectl_manifest → eks_blueprints_addons → IRSA roles → EKS cluster → KMS/Secrets/S3/ALB → security groups → VPC
+
+**Phase 3 — Post-destroy cleanup (AWS CLI, ~5 min):**
+- Delete ECR repos with `--force`
+- Delete CloudWatch log group `/aws/eks/agentic-eks-cluster/cluster`
+- Verify no orphaned ENIs, instances, ALBs, VPCs
+
+**Phase 4 — Verification:**
+- Run verification commands (see Acceptance Criteria)
+
+**Phase 5 — Issue hygiene:**
+- Close #17, #20, #21 as won't-fix
+- Update README
+
+### Data Flow
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer (local)
+    participant K8s as Kubernetes API
+    participant Karpenter as Karpenter Controller
+    participant ALB as ALB Controller
+    participant TF as Terraform
+    participant AWS as AWS APIs
+
+    Dev->>K8s: delete namespace insurance-claims
+    K8s->>AWS: delete EBS volumes (via EBS CSI)
+    Dev->>K8s: delete NodePool + EC2NodeClass
+    K8s->>Karpenter: NodePool deleted
+    Karpenter->>AWS: terminate EC2 instances
+    Dev->>K8s: delete Ingress
+    K8s->>ALB: Ingress deleted
+    ALB->>AWS: delete ALB + target groups
+    Dev->>TF: terraform destroy
+    TF->>AWS: delete EKS cluster, addons, VPC, secrets, KMS, S3, IAM
+    Dev->>AWS: delete ECR repos (CLI)
+    Dev->>AWS: delete CloudWatch log groups (CLI)
+```
+
+### Infrastructure
+
+- No new infrastructure created — this is a pure teardown
+- Terraform state bucket remains after destroy
+- KMS keys enter pending deletion (7–10 day window)
+
+### Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| VPC deletion fails due to orphaned ENIs | High (without pre-drain) | Blocks destroy | Pre-drain phase eliminates this |
+| `langgraph_storage` destroy fails (no force_destroy) | High | Blocks destroy | Add `force_destroy=true` in Phase 0 |
+| Duplicate kubectl_manifest resources cause 404 errors | Medium | TF error, re-run needed | Pre-delete via kubectl in Phase 1 |
+| Kubernetes provider auth fails mid-destroy | Low | Partial destroy, re-run needed | Pre-drain removes all kubectl_manifest dependencies |
+| `github-actions-deploy` accidentally deleted | Low | Blocks CDK work | Verified: not in TF state |
+| KMS key re-creation conflict (if CDK reuses same alias) | Low | CDK deploy fails | CDK will use different alias names |
+
+## 3. Low-Level Design
+
+### Component Design
+
+#### 3.1 Phase 0: Code Fixes
+
+**`production-terraform-addon.tf` — add `force_destroy`:**
+```hcl
+resource "aws_s3_bucket" "langgraph_storage" {
+  bucket        = "${local.name}-langgraph-storage-${random_string.bucket_suffix.result}"
+  force_destroy = true   # ADD THIS LINE
+  tags          = local.tags
+}
+```
+
+**`scripts/bootstrap-cicd.sh` or inline — patch `github-actions-deploy` policy:**
+Add to the existing inline policy document:
+```json
+{ "Effect": "Allow", "Action": ["sqs:*"], "Resource": "*" },
+{ "Effect": "Allow", "Action": ["events:*"], "Resource": "*" },
+{ "Effect": "Allow", "Action": ["s3:DeleteObjectVersion", "s3:DeleteObjectVersionTagging"], "Resource": "*" }
+```
+This is done via `aws iam put-role-policy` targeting the existing `deploy-permissions` inline policy.
+
+#### 3.2 Phase 1: Pre-Drain Script (`scripts/teardown.sh` — pre-drain section)
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER=agentic-eks-cluster
+REGION=us-west-2
+NAMESPACE=insurance-claims
+
+echo "=== Step 1: Update kubeconfig ==="
+aws eks update-kubeconfig --name "$CLUSTER" --region "$REGION"
+
+echo "=== Step 2: Delete app namespace (releases PVCs → EBS volumes) ==="
+kubectl delete namespace "$NAMESPACE" --wait=true --timeout=120s || true
+
+echo "=== Step 3: Delete Karpenter NodePools + EC2NodeClasses ==="
+kubectl delete nodepool --all --wait=true --timeout=300s || true
+kubectl delete ec2nodeclass --all --wait=true --timeout=60s || true
+
+echo "=== Step 4: Wait for Karpenter EC2 nodes to terminate ==="
+for i in $(seq 1 30); do
+  COUNT=$(aws ec2 describe-instances --region "$REGION" \
+    --filters "Name=tag:karpenter.sh/discovery,Values=$CLUSTER" \
+              "Name=instance-state-name,Values=running,pending,stopping" \
+    --query 'length(Reservations[*].Instances[*])' --output text)
+  [ "$COUNT" -eq 0 ] && echo "All Karpenter nodes terminated." && break
+  echo "  Waiting for $COUNT Karpenter node(s) to terminate... ($i/30)"
+  sleep 10
+done
+
+echo "=== Step 5: Delete all Ingress objects (triggers ALB deletion) ==="
+kubectl delete ingress --all -A --wait=true --timeout=60s || true
+
+echo "=== Step 6: Wait for ALB deletion ==="
+for i in $(seq 1 12); do
+  COUNT=$(aws elbv2 describe-load-balancers --region "$REGION" \
+    --query "length(LoadBalancers[?contains(LoadBalancerName,'k8s') || contains(LoadBalancerName,'insurance')])" \
+    --output text)
+  [ "$COUNT" -eq 0 ] && echo "ALB deleted." && break
+  echo "  Waiting for ALB deletion... ($i/12)"
+  sleep 10
+done
+
+echo "=== Pre-drain complete. Ready for terraform destroy. ==="
+```
+
+#### 3.3 Phase 2: Terraform Destroy
+
+```bash
+cd infrastructure/terraform
+terraform init   # re-init to confirm backend connectivity
+terraform plan -destroy -var-file=terraform.tfvars -out=destroy.plan
+# Review plan — confirm github-actions-deploy and state bucket NOT in plan
+terraform apply destroy.plan
+```
+
+Key verification before applying: `terraform state list | grep oidc` must NOT show `token.actions.githubusercontent.com`.
+
+#### 3.4 Phase 3: Post-Destroy Cleanup Script (teardown.sh — cleanup section)
+
+```bash
+echo "=== Post-destroy: Delete ECR repos ==="
+for REPO in web-interface coordinator analytics simulator; do
+  aws ecr delete-repository \
+    --repository-name "insurance-claims/$REPO" \
+    --force --region "$REGION" 2>/dev/null || echo "  $REPO not found (already deleted)"
+done
+
+echo "=== Post-destroy: Delete orphaned CloudWatch log groups ==="
+aws logs delete-log-group \
+  --log-group-name "/aws/eks/$CLUSTER/cluster" \
+  --region "$REGION" 2>/dev/null || echo "  Log group not found"
+
+echo "=== Post-destroy: Verify no orphaned resources ==="
+echo "--- Karpenter EC2 instances ---"
+aws ec2 describe-instances --region "$REGION" \
+  --filters "Name=tag:karpenter.sh/discovery,Values=$CLUSTER" \
+            "Name=instance-state-name,Values=running,pending" \
+  --query 'Reservations[*].Instances[*].[InstanceId,State.Name]' --output table
+
+echo "--- ALBs ---"
+aws elbv2 describe-load-balancers --region "$REGION" \
+  --query 'LoadBalancers[?contains(LoadBalancerName,`k8s`) || contains(LoadBalancerName,`insurance`)].LoadBalancerArn' \
+  --output table
+
+echo "--- VPCs ---"
+aws ec2 describe-vpcs --region "$REGION" \
+  --filters "Name=tag:Name,Values=*agentic*" \
+  --query 'Vpcs[*].[VpcId,State]' --output table
+
+echo "--- Preserved resources (should still exist) ---"
+aws iam get-role --role-name github-actions-deploy --query 'Role.RoleName' --output text
+aws s3 ls "s3://agentic-eks-terraform-state-621967485578" > /dev/null && echo "State bucket: OK"
+```
+
+### Error Handling Strategy
+
+| Error | Cause | Recovery |
+|-------|-------|----------|
+| `VPC has dependencies` during destroy | Orphaned ENIs from Karpenter/ALB | Re-run pre-drain; manually delete ENIs via `aws ec2 delete-network-interface` |
+| `BucketNotEmpty` on langgraph_storage | `force_destroy` not set | Add `force_destroy=true`, re-run `terraform apply` first, then destroy |
+| `kubectl_manifest` 404 on duplicate resource | gpu-nodepool/nodeclass defined twice | Ignore error; re-run `terraform destroy` — idempotent |
+| Kubernetes provider auth failure mid-destroy | EKS cluster deleted before kubectl_manifest | Run `terraform destroy -target=module.eks_blueprints_addons` first, then full destroy |
+| `AccessDenied` on SQS/EventBridge | Missing IAM permissions | Patch `github-actions-deploy` policy (Phase 0) |
+
+### Configuration
+
+No new configuration files. Changes are:
+- `infrastructure/terraform/production-terraform-addon.tf`: add `force_destroy = true`
+- `scripts/teardown.sh`: new file (pre-drain + post-cleanup)
+- `scripts/bootstrap-cicd.sh`: patch IAM policy section (or apply via AWS CLI directly)
+
+## 4. Task Plan
+
+### Progress Summary
+
+0 of 10 tasks complete.
+
+### Task Status
+
+| ID | Task | Status | Depends On |
+|----|------|--------|------------|
+| T1 | Add `force_destroy=true` to `langgraph_storage` S3 bucket | ⬜ TODO | — |
+| T2 | Patch `github-actions-deploy` IAM policy (sqs, events, s3:DeleteObjectVersion) | ⬜ TODO | — |
+| T3 | Create `scripts/teardown.sh` (pre-drain + post-cleanup) | ⬜ TODO | T1, T2 |
+| T4 | Run pre-drain: delete namespace, NodePools, Ingress; verify no orphans | ⬜ TODO | T3 |
+| T5 | Run `terraform plan -destroy` and review (confirm preserved resources not in plan) | ⬜ TODO | T4 |
+| T6 | Run `terraform apply destroy.plan` | ⬜ TODO | T5 |
+| T7 | Post-destroy cleanup: delete ECR repos + CloudWatch log groups | ⬜ TODO | T6 |
+| T8 | Run verification commands; confirm all acceptance criteria pass | ⬜ TODO | T7 |
+| T9 | Close issues #17, #20, #21 as won't-fix with explanation | ⬜ TODO | T8 |
+| T10 | Update README to reflect teardown complete, CDK migration in progress | ⬜ TODO | T9 |
+
+### Eligible Tasks (can start now)
+
+- T1 — code change, no dependencies
+- T2 — IAM policy patch, no dependencies
+
+### Dependency Graph
+
+```mermaid
+graph LR
+    T1 --> T3
+    T2 --> T3
+    T3 --> T4
+    T4 --> T5
+    T5 --> T6
+    T6 --> T7
+    T7 --> T8
+    T8 --> T9
+    T9 --> T10
+```
+
+### Detailed Task Definitions
+
+**T1 — Add `force_destroy=true` to `langgraph_storage`**
+- File: `infrastructure/terraform/production-terraform-addon.tf`
+- Change: add `force_destroy = true` to `aws_s3_bucket.langgraph_storage`
+- Verify: `terraform plan` shows no unexpected changes (force_destroy is not a real AWS attribute, no diff expected)
+
+**T2 — Patch `github-actions-deploy` IAM policy**
+- ✅ VERIFIED NO-OP: Policy already contains `sqs:*` (Sid: SQS), `events:*` (Sid: EventBridge), and `s3:*` (Sid: S3) which covers `s3:DeleteObjectVersion`. Confirmed via `aws iam simulate-principal-policy` — all three actions return `allowed`.
+- No change required.
+
+**T3 — Create `scripts/teardown.sh`**
+- Combines pre-drain steps and post-cleanup steps from LLD section 3.2 and 3.4
+- Make executable: `chmod +x scripts/teardown.sh`
+- Dry-run test: verify script syntax with `bash -n scripts/teardown.sh`
+
+**T4 — Run pre-drain**
+- Execute pre-drain section of `scripts/teardown.sh` (or run steps manually)
+- Gate: do not proceed until Karpenter EC2 count = 0 AND ALB count = 0
+
+**T5 — Review destroy plan**
+- `terraform plan -destroy -var-file=terraform.tfvars -out=destroy.plan`
+- Verify: `github-actions-deploy` NOT in plan; state bucket NOT in plan; GitHub OIDC provider NOT in plan
+- Verify: `terraform state list | grep oidc` shows only EKS OIDC provider
+
+**T6 — Execute `terraform destroy`**
+- `terraform apply destroy.plan`
+- Expected duration: 20–35 min
+- If VPC deletion fails: check for orphaned ENIs, delete manually, re-run
+
+**T7 — Post-destroy cleanup**
+- Delete ECR repos: `aws ecr delete-repository --force` for each of 4 repos
+- Delete CloudWatch log group: `aws logs delete-log-group --log-group-name /aws/eks/agentic-eks-cluster/cluster`
+
+**T8 — Verification**
+- Run all verification commands from Acceptance Criteria section
+- All checks must pass before proceeding
+
+**T9 — Close issues**
+- Close #17 (torch CVEs): "Won't fix — analytics image removed as part of EKS teardown (#25). Moot."
+- Close #20 (coordinator crash): "Won't fix — EKS stack torn down (#25). Moot."
+- Close #21 (ExternalSecrets IRSA): "Won't fix — EKS stack torn down (#25). Moot."
+
+**T10 — Update README**
+- Update badges (remove EKS/Kubernetes/Terraform badges, add CDK/Fargate/DynamoDB)
+- Update architecture section to note migration in progress
+- Update Quick Start to note current stack is being replaced

--- a/infrastructure/terraform/production-terraform-addon.tf
+++ b/infrastructure/terraform/production-terraform-addon.tf
@@ -50,7 +50,8 @@ resource "aws_iam_policy" "langgraph_service_policy" {
 
 # S3 Bucket for LangGraph Storage
 resource "aws_s3_bucket" "langgraph_storage" {
-  bucket = "${local.name}-langgraph-storage-${random_string.bucket_suffix.result}"
+  bucket        = "${local.name}-langgraph-storage-${random_string.bucket_suffix.result}"
+  force_destroy = true # Required for terraform destroy to succeed on versioned bucket
 
   tags = local.tags
 }

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -95,10 +95,12 @@ phase_pre_drain() {
     warn "No EC2NodeClasses found"
 
   log "Waiting for Karpenter-provisioned EC2 nodes to terminate (max 5 min)..."
+  # Use karpenter.sh/nodepool tag — NOT karpenter.sh/discovery, which is also
+  # applied to managed node group instances via the node security group.
   for i in $(seq 1 30); do
     COUNT=$(aws ec2 describe-instances --region "$REGION" \
       --filters \
-        "Name=tag:karpenter.sh/discovery,Values=$CLUSTER" \
+        "Name=tag-key,Values=karpenter.sh/nodepool" \
         "Name=instance-state-name,Values=running,pending,stopping,shutting-down" \
       --query 'length(Reservations[*].Instances[*])' --output text 2>/dev/null || echo "0")
     if [[ "$COUNT" -eq 0 ]]; then
@@ -113,7 +115,7 @@ phase_pre_drain() {
   log "Pre-drain complete. Verifying no blockers remain..."
   KARPENTER_NODES=$(aws ec2 describe-instances --region "$REGION" \
     --filters \
-      "Name=tag:karpenter.sh/discovery,Values=$CLUSTER" \
+      "Name=tag-key,Values=karpenter.sh/nodepool" \
       "Name=instance-state-name,Values=running,pending" \
     --query 'length(Reservations[*].Instances[*])' --output text 2>/dev/null || echo "0")
   ALB_COUNT=$(aws elbv2 describe-load-balancers --region "$REGION" \
@@ -248,7 +250,7 @@ phase_verify() {
 
   check "No Karpenter EC2 nodes running" \
     "$(aws ec2 describe-instances --region "$REGION" \
-      --filters "Name=tag:karpenter.sh/discovery,Values=$CLUSTER" "Name=instance-state-name,Values=running,pending" \
+      --filters "Name=tag-key,Values=karpenter.sh/nodepool" "Name=instance-state-name,Values=running,pending" \
       --query 'Reservations[*].Instances[*].InstanceId' --output text 2>/dev/null || true)" \
     "empty"
 

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# teardown.sh — EKS cluster teardown for issue #25
+# Usage: ./scripts/teardown.sh [--pre-drain | --destroy | --post-cleanup | --verify | --all]
+#
+# Phases:
+#   --pre-drain    Delete K8s Ingress/workloads/NodePools to unblock VPC deletion
+#   --destroy      Run terraform destroy (requires pre-drain to have completed)
+#   --post-cleanup Delete ECR repos and orphaned CloudWatch log groups
+#   --verify       Confirm no orphaned resources remain
+#   --all          Run all phases in sequence (interactive confirmation between phases)
+#
+# PRESERVED (never touched):
+#   - IAM role: github-actions-deploy
+#   - OIDC provider: token.actions.githubusercontent.com
+#   - S3 bucket: agentic-eks-terraform-state-<account>
+
+set -euo pipefail
+
+CLUSTER="agentic-eks-cluster"
+REGION="us-west-2"
+NAMESPACE="insurance-claims"
+TF_DIR="$(cd "$(dirname "$0")/../infrastructure/terraform" && pwd)"
+KUBECTL="$(cd "$(dirname "$0")/.." && pwd)/kubectl"
+
+# Fall back to system kubectl if local binary not present
+if [[ ! -x "$KUBECTL" ]]; then
+  KUBECTL="kubectl"
+fi
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log()  { echo -e "${GREEN}==>${NC} $*"; }
+warn() { echo -e "${YELLOW}WARN:${NC} $*"; }
+die()  { echo -e "${RED}ERROR:${NC} $*" >&2; exit 1; }
+
+confirm() {
+  read -r -p "$1 [y/N] " response
+  [[ "$response" =~ ^[Yy]$ ]] || die "Aborted."
+}
+
+# Validate AWS credentials and return account ID
+get_account_id() {
+  local ACCOUNT
+  ACCOUNT=$(aws sts get-caller-identity --query 'Account' --output text 2>/dev/null) || \
+    die "AWS credentials invalid or expired. Run: mwinit -s"
+  echo "$ACCOUNT"
+}
+
+# ---------------------------------------------------------------------------
+phase_pre_drain() {
+  log "Phase 1: Pre-drain — removing K8s resources outside Terraform state"
+
+  local ACCOUNT
+  ACCOUNT=$(get_account_id)
+  log "AWS account: $ACCOUNT, region: $REGION"
+
+  log "Updating kubeconfig..."
+  aws eks update-kubeconfig --name "$CLUSTER" --region "$REGION"
+
+  # IMPORTANT: Delete Ingress FIRST so ALB controller (in kube-system) is still
+  # running when it processes the deletion and calls elbv2:DeleteLoadBalancer.
+  # Deleting the namespace first garbage-collects Ingress objects without giving
+  # the controller a clean reconcile, leaving an orphaned ALB that blocks VPC deletion.
+  log "Deleting Ingress objects FIRST (ALB controller must be alive to delete the ALB)..."
+  "$KUBECTL" delete ingress --all -A --wait=true --timeout=60s 2>/dev/null || \
+    warn "No Ingress objects found"
+
+  log "Waiting for ALB deletion (max 4 min)..."
+  for i in $(seq 1 24); do
+    COUNT=$(aws elbv2 describe-load-balancers --region "$REGION" \
+      --query "length(LoadBalancers[?contains(LoadBalancerName,'k8s') || contains(LoadBalancerName,'insurance') || contains(LoadBalancerName,'langgraph')])" \
+      --output text 2>/dev/null || echo "0")
+    if [[ "$COUNT" -eq 0 ]]; then
+      log "ALB deleted."
+      break
+    fi
+    echo "  Waiting for $COUNT ALB(s) to be deleted by ALB controller... ($i/24)"
+    sleep 10
+    [[ "$i" -eq 24 ]] && die "ALB not deleted after 4 min. Check ALB controller logs: kubectl logs -n kube-system -l app.kubernetes.io/name=aws-load-balancer-controller"
+  done
+
+  log "Deleting namespace $NAMESPACE (releases PVCs → EBS volumes deleted by EBS CSI)..."
+  "$KUBECTL" delete namespace "$NAMESPACE" --wait=true --timeout=180s 2>/dev/null || \
+    warn "Namespace $NAMESPACE not found or already deleted"
+
+  log "Deleting Karpenter NodePools..."
+  "$KUBECTL" delete nodepool --all --wait=true --timeout=300s 2>/dev/null || \
+    warn "No NodePools found"
+
+  log "Deleting Karpenter EC2NodeClasses..."
+  "$KUBECTL" delete ec2nodeclass --all --wait=true --timeout=60s 2>/dev/null || \
+    warn "No EC2NodeClasses found"
+
+  log "Waiting for Karpenter-provisioned EC2 nodes to terminate (max 5 min)..."
+  for i in $(seq 1 30); do
+    COUNT=$(aws ec2 describe-instances --region "$REGION" \
+      --filters \
+        "Name=tag:karpenter.sh/discovery,Values=$CLUSTER" \
+        "Name=instance-state-name,Values=running,pending,stopping,shutting-down" \
+      --query 'length(Reservations[*].Instances[*])' --output text 2>/dev/null || echo "0")
+    if [[ "$COUNT" -eq 0 ]]; then
+      log "All Karpenter nodes terminated."
+      break
+    fi
+    echo "  Waiting for $COUNT Karpenter node(s)... ($i/30)"
+    sleep 10
+    [[ "$i" -eq 30 ]] && die "Karpenter nodes did not terminate in time. Check AWS console."
+  done
+
+  log "Pre-drain complete. Verifying no blockers remain..."
+  KARPENTER_NODES=$(aws ec2 describe-instances --region "$REGION" \
+    --filters \
+      "Name=tag:karpenter.sh/discovery,Values=$CLUSTER" \
+      "Name=instance-state-name,Values=running,pending" \
+    --query 'length(Reservations[*].Instances[*])' --output text 2>/dev/null || echo "0")
+  ALB_COUNT=$(aws elbv2 describe-load-balancers --region "$REGION" \
+    --query "length(LoadBalancers[?contains(LoadBalancerName,'k8s') || contains(LoadBalancerName,'insurance') || contains(LoadBalancerName,'langgraph')])" \
+    --output text 2>/dev/null || echo "0")
+
+  echo ""
+  echo "  Karpenter EC2 nodes remaining: $KARPENTER_NODES (want: 0)"
+  echo "  ALBs remaining:                $ALB_COUNT (want: 0)"
+  echo ""
+
+  [[ "$KARPENTER_NODES" -eq 0 && "$ALB_COUNT" -eq 0 ]] || \
+    die "Blockers remain. Resolve before running --destroy."
+
+  log "Pre-drain PASSED. Safe to run --destroy."
+}
+
+# ---------------------------------------------------------------------------
+phase_destroy() {
+  log "Phase 2: terraform destroy"
+
+  local ACCOUNT
+  ACCOUNT=$(get_account_id)
+  local STATE_BUCKET="agentic-eks-terraform-state-${ACCOUNT}"
+
+  # Safety check: confirm preserved resources are NOT in TF state
+  log "Verifying preserved resources are not in Terraform state..."
+  cd "$TF_DIR"
+
+  # Check TF state list for any resource referencing the GitHub OIDC provider
+  OIDC_IN_STATE=$(terraform state list 2>/dev/null | grep "token.actions.githubusercontent.com" || true)
+  [[ -z "$OIDC_IN_STATE" ]] || die "GitHub OIDC provider found in TF state — STOP. Do not destroy."
+
+  # Check TF state list for github-actions-deploy role
+  DEPLOY_ROLE_IN_STATE=$(terraform state list 2>/dev/null | grep "github-actions-deploy" || true)
+  [[ -z "$DEPLOY_ROLE_IN_STATE" ]] || die "github-actions-deploy role found in TF state — STOP. Do not destroy."
+
+  # Belt-and-suspenders: verify preserved resources still exist via AWS API
+  aws iam get-role --role-name github-actions-deploy --query 'Role.RoleName' --output text > /dev/null || \
+    die "github-actions-deploy role not found in AWS — unexpected state."
+  aws s3 ls "s3://${STATE_BUCKET}" --region "$REGION" > /dev/null 2>&1 || \
+    die "State bucket ${STATE_BUCKET} not accessible — unexpected state."
+
+  log "Safety check passed — preserved resources not in state and verified to exist."
+
+  log "Running terraform plan -destroy..."
+  terraform plan -destroy -var-file=terraform.tfvars -out=destroy.plan
+
+  echo ""
+  warn "⚠️  REVIEW THE PLAN ABOVE before proceeding."
+  warn "    Confirm: github-actions-deploy NOT in plan"
+  warn "    Confirm: ${STATE_BUCKET} NOT in plan"
+  echo ""
+  confirm "Apply destroy plan?"
+
+  log "Running terraform apply destroy.plan (timeout: 30 min)..."
+  timeout 1800 terraform apply destroy.plan || {
+    EXIT=$?
+    rm -f destroy.plan
+    [[ $EXIT -eq 124 ]] && die "terraform apply timed out after 30 min. Check AWS console for stuck resources."
+    die "terraform apply failed with exit code $EXIT."
+  }
+
+  rm -f destroy.plan
+  log "terraform destroy complete."
+}
+
+# ---------------------------------------------------------------------------
+phase_post_cleanup() {
+  log "Phase 3: Post-destroy cleanup"
+
+  get_account_id > /dev/null  # validate credentials
+
+  log "Deleting ECR repositories..."
+  ECR_REPOS=$(aws ecr describe-repositories --region "$REGION" \
+    --query 'repositories[?starts_with(repositoryName,`insurance-claims`)].repositoryName' \
+    --output text 2>/dev/null || true)
+
+  if [[ -z "$ECR_REPOS" ]]; then
+    warn "No insurance-claims ECR repos found (already deleted?)"
+  else
+    for REPO in $ECR_REPOS; do
+      log "  Deleting ECR repo: $REPO"
+      aws ecr delete-repository --repository-name "$REPO" --force --region "$REGION" 2>/dev/null || \
+        warn "  Could not delete $REPO (may already be gone)"
+    done
+  fi
+
+  log "Deleting orphaned CloudWatch log groups..."
+  for LG in \
+    "/aws/eks/${CLUSTER}/cluster" \
+    "/aws/eks/${CLUSTER}/langgraph"; do
+    aws logs delete-log-group --log-group-name "$LG" --region "$REGION" 2>/dev/null && \
+      log "  Deleted: $LG" || warn "  Not found (already deleted?): $LG"
+  done
+
+  log "Post-cleanup complete."
+}
+
+# ---------------------------------------------------------------------------
+phase_verify() {
+  log "Phase 4: Verification"
+  local PASS=0
+  local FAIL=0
+
+  check() {
+    local DESC="$1"
+    local RESULT="$2"
+    local WANT="$3"  # "empty" or "exists"
+    if [[ "$WANT" == "empty" && -z "$RESULT" ]]; then
+      echo -e "  ${GREEN}✓${NC} $DESC"
+      PASS=$(( PASS + 1 ))
+    elif [[ "$WANT" == "exists" && -n "$RESULT" ]]; then
+      echo -e "  ${GREEN}✓${NC} $DESC"
+      PASS=$(( PASS + 1 ))
+    else
+      echo -e "  ${RED}✗${NC} $DESC (got: ${RESULT:-<empty>})"
+      FAIL=$(( FAIL + 1 ))
+    fi
+  }
+
+  local ACCOUNT
+  ACCOUNT=$(get_account_id)
+  local STATE_BUCKET="agentic-eks-terraform-state-${ACCOUNT}"
+
+  echo ""
+  echo "=== Acceptance Criteria ==="
+
+  check "EKS cluster deleted" \
+    "$(aws eks describe-cluster --name "$CLUSTER" --region "$REGION" 2>&1 | grep -i 'not found\|ResourceNotFoundException\|error' || true)" \
+    "exists"
+
+  check "No Karpenter EC2 nodes running" \
+    "$(aws ec2 describe-instances --region "$REGION" \
+      --filters "Name=tag:karpenter.sh/discovery,Values=$CLUSTER" "Name=instance-state-name,Values=running,pending" \
+      --query 'Reservations[*].Instances[*].InstanceId' --output text 2>/dev/null || true)" \
+    "empty"
+
+  check "No orphaned ALBs (k8s/insurance/langgraph)" \
+    "$(aws elbv2 describe-load-balancers --region "$REGION" \
+      --query "LoadBalancers[?contains(LoadBalancerName,'k8s') || contains(LoadBalancerName,'insurance') || contains(LoadBalancerName,'langgraph')].LoadBalancerArn" \
+      --output text 2>/dev/null || true)" \
+    "empty"
+
+  check "No VPC with agentic tag" \
+    "$(aws ec2 describe-vpcs --region "$REGION" \
+      --filters "Name=tag:Name,Values=*agentic*" \
+      --query 'Vpcs[*].VpcId' --output text 2>/dev/null || true)" \
+    "empty"
+
+  check "No orphaned EBS volumes (kubernetes-owned)" \
+    "$(aws ec2 describe-volumes --region "$REGION" \
+      --filters "Name=tag:kubernetes.io/cluster/$CLUSTER,Values=owned" "Name=status,Values=available" \
+      --query 'Volumes[*].VolumeId' --output text 2>/dev/null || true)" \
+    "empty"
+
+  check "No ECR repos for insurance-claims" \
+    "$(aws ecr describe-repositories --region "$REGION" \
+      --query 'repositories[?starts_with(repositoryName,`insurance-claims`)].repositoryName' \
+      --output text 2>/dev/null || true)" \
+    "empty"
+
+  check "No orphaned CW log group /aws/eks/$CLUSTER/cluster" \
+    "$(aws logs describe-log-groups --region "$REGION" \
+      --log-group-name-prefix "/aws/eks/$CLUSTER/cluster" \
+      --query 'logGroups[*].logGroupName' --output text 2>/dev/null || true)" \
+    "empty"
+
+  check "github-actions-deploy role preserved" \
+    "$(aws iam get-role --role-name github-actions-deploy --query 'Role.RoleName' --output text 2>/dev/null || true)" \
+    "exists"
+
+  check "GitHub OIDC provider preserved" \
+    "$(aws iam get-open-id-connect-provider \
+      --open-id-connect-provider-arn "arn:aws:iam::${ACCOUNT}:oidc-provider/token.actions.githubusercontent.com" \
+      --query 'Url' --output text 2>/dev/null || true)" \
+    "exists"
+
+  check "Terraform state bucket preserved" \
+    "$(aws s3 ls "s3://${STATE_BUCKET}" --region "$REGION" 2>/dev/null | head -1 || true)" \
+    "exists"
+
+  echo ""
+  echo "=== Results: ${PASS} passed, ${FAIL} failed ==="
+  echo ""
+
+  [[ "$FAIL" -eq 0 ]] && log "All acceptance criteria PASSED." || warn "$FAIL check(s) failed — review above."
+  return "$FAIL"
+}
+
+# ---------------------------------------------------------------------------
+usage() {
+  echo "Usage: $0 [--pre-drain | --destroy | --post-cleanup | --verify | --all]"
+  echo ""
+  echo "  --pre-drain    Delete K8s Ingress/workloads/NodePools (run first)"
+  echo "  --destroy      terraform plan -destroy + apply (requires pre-drain)"
+  echo "  --post-cleanup Delete ECR repos + orphaned CloudWatch log groups"
+  echo "  --verify       Check all acceptance criteria"
+  echo "  --all          Run all phases with confirmation prompts"
+  exit 1
+}
+
+[[ $# -eq 0 ]] && usage
+
+case "$1" in
+  --pre-drain)    phase_pre_drain ;;
+  --destroy)      phase_destroy ;;
+  --post-cleanup) phase_post_cleanup ;;
+  --verify)       phase_verify ;;
+  --all)
+    phase_pre_drain
+    echo ""
+    confirm "Pre-drain complete. Proceed to terraform destroy?"
+    phase_destroy
+    echo ""
+    confirm "Destroy complete. Proceed to post-cleanup (deletes ECR repos — irreversible)?"
+    phase_post_cleanup
+    echo ""
+    phase_verify
+    ;;
+  *) usage ;;
+esac


### PR DESCRIPTION
## Summary

Tears down the EKS cluster `agentic-eks-cluster` and all supporting Terraform-managed infrastructure. The cluster was generating ~300 Critical/High Linux kernel CVEs with no path to resolution that isn't a perpetual treadmill. The target architecture (CDK + Fargate, issues #2–#5) eliminates worker node OS management entirely.

**Preserved:** `github-actions-deploy` IAM role, GitHub Actions OIDC provider, Terraform state bucket — all confirmed intact post-teardown.

## Changes

### Infrastructure (Terraform)
- `production-terraform-addon.tf`: added `force_destroy = true` to `aws_s3_bucket.langgraph_storage` (required for destroy to succeed on versioned bucket)

### Scripts
- `scripts/teardown.sh`: new 4-phase teardown script (pre-drain → destroy → post-cleanup → verify)
  - Pre-drain deletes Ingress **before** namespace (ALB controller must be alive to delete the ALB in AWS)
  - Waits for Karpenter nodes using `karpenter.sh/nodepool` tag (not `karpenter.sh/discovery`, which also matches managed node group instances)
  - ALB filter covers `k8s`, `insurance`, and `langgraph` names
  - Safety checks: verifies preserved resources not in TF state before destroy
  - 10-point verification phase

### Docs
- `docs/specs/In-Progress/issue-25-eks-teardown-spec.md`: full spec with research brief, edge cases, and task plan

### README
- Updated badges (EKS → Fargate/CDK/DynamoDB)
- Added teardown notice to Quick Start
- Updated Technology Stack table to target architecture

## What Was Destroyed (executed locally)

- EKS cluster `agentic-eks-cluster` + managed node group (2× m5.large)
- VPC, 3 NAT gateways, 6 subnets, security groups, IGW, flow logs
- Karpenter 1.7.1 (SQS queue, EventBridge rules, IAM roles, Helm release)
- ALB controller v2.17.1, External Secrets 0.11.0, metrics-server, EBS CSI driver
- KMS keys (7/10-day pending deletion window)
- Secrets Manager secrets (recovery_window=0, immediate deletion)
- S3 buckets (langgraph-storage, app-data)
- 12 ECR repos (insurance-claims/*)
- CloudWatch log groups
- 171 Terraform resources total

## Testing

- [x] `terraform validate` passes
- [x] `terraform plan -destroy` reviewed — preserved resources confirmed not in plan
- [x] `terraform apply destroy.plan` completed — exit code 0, 171 resources destroyed
- [x] `./scripts/teardown.sh --verify` — 10/10 acceptance criteria passed
- [x] `bash -n scripts/teardown.sh` — syntax valid

## Deployment Notes

This PR documents a completed teardown — no deployment needed. The Terraform state bucket is preserved for the CDK migration (issues #2–#5).

**Next steps:** Issue #2 (CDK TypeScript) is now unblocked and is the top priority.

## Security Considerations

- `github-actions-deploy` IAM role preserved and verified functional
- GitHub Actions OIDC provider preserved
- KMS keys in pending deletion (7–10 day window) — cannot be cancelled without re-enabling
- No secrets or credentials in committed files

Closes #25
Also closes #17, #21 (won't-fix — EKS stack gone)